### PR TITLE
module: improve error message for top-level await in CommonJS

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -106,6 +106,7 @@
       'src/node_config.cc',
       'src/node_constants.cc',
       'src/node_contextify.cc',
+      'src/module_utils.cc',
       'src/node_credentials.cc',
       'src/node_debug.cc',
       'src/node_dir.cc',
@@ -314,6 +315,7 @@
       'src/udp_wrap.h',
       'src/util.h',
       'src/util-inl.h',
+      'src/module_utils.h'
     ],
     'node_crypto_sources': [
       'src/crypto/crypto_aes.cc',

--- a/src/module_utils.cc
+++ b/src/module_utils.cc
@@ -1,0 +1,34 @@
+#include "module_utils.h"
+#include <v8.h>
+#include <string>
+
+// Top-level await control
+bool ContainsTopLevelAwait(v8::Local<v8::String> code) {
+  v8::String::Utf8Value utf8_value(v8::Isolate::GetCurrent(), code);
+  std::string source_code(*utf8_value);
+  return source_code.find("await") != std::string::npos;
+}
+
+// Checks if the string ends with a specific suffix
+bool EndsWith(const v8::Local<v8::String>& v8_str, const std::string& suffix) {
+  v8::String::Utf8Value utf8(v8::Isolate::GetCurrent(), v8_str);
+  std::string str(*utf8);
+  return str.size() >= suffix.size() &&
+         str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+// function to check the “type” field in package.json (not done yet)
+bool contains_package_json_with_type(const std::string& type) {
+  // TODO(mertcanaltin): Implementation
+  // can be done with a real file read operation.
+  return false;
+}
+// module  mjs control
+bool is_module(const std::string& filename) {
+  auto isolate = v8::Isolate::GetCurrent();
+  v8::Local<v8::String> v8_filename =
+      v8::String::NewFromUtf8(isolate, filename.c_str()).ToLocalChecked();
+
+  return EndsWith(v8_filename, ".mjs") ||
+         contains_package_json_with_type("module");
+}

--- a/src/module_utils.h
+++ b/src/module_utils.h
@@ -1,0 +1,11 @@
+#ifndef SRC_MODULE_UTILS_H_
+#define SRC_MODULE_UTILS_H_
+
+#include <v8.h>
+#include <string>
+
+bool ContainsTopLevelAwait(v8::Local<v8::String> code);
+bool EndsWith(const v8::Local<v8::String>& v8_str, const std::string& suffix);
+bool is_module(const std::string& filename);
+
+#endif  // SRC_MODULE_UTILS_H_


### PR DESCRIPTION
v2 

Added a specific error message for using top-level await in CommonJS modules. The error now suggests using ESM or wrapping await in an async function for clarity.

Fixes: https://github.com/nodejs/node/issues/55776